### PR TITLE
Timeout after 10s; remove update-notifier from critical path

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,2 +1,6 @@
 #!/usr/bin/env node
 require('./dist/flossbank.bundle')()
+
+try {
+  require('update-notifier')({ pkg: require('./package.json') }).notify()
+} catch (_) {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -395,12 +395,6 @@
 				"fastq": "^1.6.0"
 			}
 		},
-		"@sindresorhus/is": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-			"dev": true
-		},
 		"@sinonjs/commons": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
@@ -437,20 +431,10 @@
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
 		},
-		"@szmarczak/http-timer": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-			"dev": true,
-			"requires": {
-				"defer-to-connect": "^1.0.1"
-			}
-		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -675,6 +659,15 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
+		"abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"requires": {
+				"event-target-shim": "^5.0.0"
+			}
+		},
 		"acorn": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
@@ -715,7 +708,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
 			"integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
-			"dev": true,
 			"requires": {
 				"string-width": "^3.0.0"
 			},
@@ -724,7 +716,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
@@ -754,8 +745,7 @@
 		"ansi-regex": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-			"dev": true
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 		},
 		"ansi-split": {
 			"version": "1.0.1",
@@ -778,7 +768,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
 			"integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
-			"dev": true,
 			"requires": {
 				"@types/color-name": "^1.1.1",
 				"color-convert": "^2.0.1"
@@ -1406,7 +1395,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
 			"integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
-			"dev": true,
 			"requires": {
 				"ansi-align": "^3.0.0",
 				"camelcase": "^5.3.1",
@@ -1422,7 +1410,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
 					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
@@ -1628,38 +1615,6 @@
 				}
 			}
 		},
-		"cacheable-request": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-			"dev": true,
-			"requires": {
-				"clone-response": "^1.0.2",
-				"get-stream": "^5.1.0",
-				"http-cache-semantics": "^4.0.0",
-				"keyv": "^3.0.0",
-				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^4.1.0",
-				"responselike": "^1.0.2"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"lowercase-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-					"dev": true
-				}
-			}
-		},
 		"caching-transform": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
@@ -1773,8 +1728,7 @@
 		"camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"camelcase-keys": {
 			"version": "4.2.0",
@@ -1893,8 +1847,7 @@
 		"ci-info": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-			"dev": true
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
 		},
 		"ci-parallel-vars": {
 			"version": "1.0.0",
@@ -1956,8 +1909,7 @@
 		"cli-boxes": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
-			"dev": true
+			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
 		},
 		"cli-cursor": {
 			"version": "3.1.0",
@@ -2024,9 +1976,15 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-			"dev": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
+			},
+			"dependencies": {
+				"mimic-response": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+				}
 			}
 		},
 		"code-excerpt": {
@@ -2052,7 +2010,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"requires": {
 				"color-name": "~1.1.4"
 			}
@@ -2060,8 +2017,7 @@
 		"color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
 		"commander": {
 			"version": "2.20.3",
@@ -2163,7 +2119,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.0.tgz",
 			"integrity": "sha512-eE/hvMs7qw7DlcB5JPRnthmrITuHMmACUJAp89v6PT6iOqzoLS7HRWhBtuHMlhNHo2AhUSA/3Dh1bKNJHcublQ==",
-			"dev": true,
 			"requires": {
 				"dot-prop": "^5.1.0",
 				"graceful-fs": "^4.1.2",
@@ -2351,8 +2306,7 @@
 		"crypto-random-string": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-			"dev": true
+			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -2432,15 +2386,6 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
-		"decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"dev": true,
-			"requires": {
-				"mimic-response": "^1.0.0"
-			}
-		},
 		"deep-equal": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -2458,8 +2403,7 @@
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -2488,8 +2432,7 @@
 		"defer-to-connect": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
-			"integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ==",
-			"dev": true
+			"integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ=="
 		},
 		"define-properties": {
 			"version": "1.1.3",
@@ -2685,7 +2628,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
 			"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
-			"dev": true,
 			"requires": {
 				"is-obj": "^2.0.0"
 			}
@@ -2693,8 +2635,7 @@
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
 		"duplexify": {
 			"version": "3.7.1",
@@ -2732,8 +2673,7 @@
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-			"dev": true
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
 		},
 		"emojis-list": {
 			"version": "2.1.0",
@@ -2755,7 +2695,6 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -3394,6 +3333,12 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
+		},
+		"event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
 			"dev": true
 		},
 		"events": {
@@ -4049,15 +3994,6 @@
 			"integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
 			"dev": true
 		},
-		"get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-			"dev": true,
-			"requires": {
-				"pump": "^3.0.0"
-			}
-		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -4091,7 +4027,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
 			"integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
-			"dev": true,
 			"requires": {
 				"ini": "^1.3.5"
 			}
@@ -4153,30 +4088,10 @@
 				"slash": "^3.0.0"
 			}
 		},
-		"got": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-			"dev": true,
-			"requires": {
-				"@sindresorhus/is": "^0.14.0",
-				"@szmarczak/http-timer": "^1.1.2",
-				"cacheable-request": "^6.0.0",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^4.1.0",
-				"lowercase-keys": "^1.0.1",
-				"mimic-response": "^1.0.1",
-				"p-cancelable": "^1.0.0",
-				"to-readable-stream": "^1.0.0",
-				"url-parse-lax": "^3.0.0"
-			}
-		},
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-			"dev": true
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
 		},
 		"handlebars": {
 			"version": "4.5.3",
@@ -4210,8 +4125,7 @@
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 		},
 		"has-symbols": {
 			"version": "1.0.1",
@@ -4282,8 +4196,7 @@
 		"has-yarn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
-			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
-			"dev": true
+			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
 		},
 		"hash-base": {
 			"version": "3.0.4",
@@ -4344,8 +4257,7 @@
 		"http-cache-semantics": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-			"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
-			"dev": true
+			"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
 		},
 		"https-browserify": {
 			"version": "1.0.0",
@@ -4507,8 +4419,7 @@
 		"import-lazy": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-			"dev": true
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
 		},
 		"import-local": {
 			"version": "3.0.2",
@@ -4523,8 +4434,7 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"indent-string": {
 			"version": "4.0.0",
@@ -4557,8 +4467,7 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "6.5.2",
@@ -4734,7 +4643,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
 			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-			"dev": true,
 			"requires": {
 				"ci-info": "^2.0.0"
 			}
@@ -4811,8 +4719,7 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-glob": {
 			"version": "4.0.1",
@@ -4827,7 +4734,6 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.1.tgz",
 			"integrity": "sha512-oiEcGoQbGc+3/iijAijrK2qFpkNoNjsHOm/5V5iaeydyrS/hnwaRCEgH5cpW0P3T1lSjV5piB7S5b5lEugNLhg==",
-			"dev": true,
 			"requires": {
 				"global-dirs": "^2.0.1",
 				"is-path-inside": "^3.0.1"
@@ -4836,16 +4742,14 @@
 				"is-path-inside": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-					"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
-					"dev": true
+					"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
 				}
 			}
 		},
 		"is-npm": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
-			"integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
-			"dev": true
+			"integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig=="
 		},
 		"is-number": {
 			"version": "7.0.0",
@@ -4856,8 +4760,7 @@
 		"is-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"dev": true
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
 		},
 		"is-observable": {
 			"version": "2.0.0",
@@ -4943,8 +4846,7 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-url": {
 			"version": "1.2.4",
@@ -4973,8 +4875,7 @@
 		"is-yarn-global": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
-			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
-			"dev": true
+			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
 		},
 		"isarray": {
 			"version": "0.0.1",
@@ -5142,12 +5043,6 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
-		"json-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-			"dev": true
-		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -5170,6 +5065,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
 		"json5": {
@@ -5203,15 +5104,6 @@
 			"integrity": "sha1-HoBFQlABjbrUw/6USX1uZ7YmnHc=",
 			"dev": true
 		},
-		"keyv": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-			"dev": true,
-			"requires": {
-				"json-buffer": "3.0.0"
-			}
-		},
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -5228,7 +5120,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
 			"integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-			"dev": true,
 			"requires": {
 				"package-json": "^6.3.0"
 			}
@@ -5379,12 +5270,6 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
-		"lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"dev": true
-		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -5399,7 +5284,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
 			"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
-			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
 			}
@@ -5582,12 +5466,6 @@
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true
 		},
-		"mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-			"dev": true
-		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -5612,8 +5490,7 @@
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-			"dev": true
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -5813,6 +5690,19 @@
 				}
 			}
 		},
+		"nock": {
+			"version": "11.7.2",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-11.7.2.tgz",
+			"integrity": "sha512-7swr5bL1xBZ5FctyubjxEVySXOSebyqcL7Vy1bx1nS9IUqQWj81cmKjVKJLr8fHhtzI1MV8nyCdENA/cGcY1+Q==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.13",
+				"mkdirp": "^0.5.0",
+				"propagate": "^2.0.0"
+			}
+		},
 		"node-fetch": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -5887,8 +5777,7 @@
 		"normalize-url": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-			"dev": true
+			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -6151,7 +6040,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -6333,12 +6221,6 @@
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
-		"p-cancelable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-			"dev": true
-		},
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -6403,12 +6285,130 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
 			"integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
-			"dev": true,
 			"requires": {
 				"got": "^9.6.0",
 				"registry-auth-token": "^4.0.0",
 				"registry-url": "^5.0.0",
 				"semver": "^6.2.0"
+			},
+			"dependencies": {
+				"@sindresorhus/is": {
+					"version": "0.14.0",
+					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+					"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+				},
+				"@szmarczak/http-timer": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+					"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+					"requires": {
+						"defer-to-connect": "^1.0.1"
+					}
+				},
+				"cacheable-request": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+					"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+					"requires": {
+						"clone-response": "^1.0.2",
+						"get-stream": "^5.1.0",
+						"http-cache-semantics": "^4.0.0",
+						"keyv": "^3.0.0",
+						"lowercase-keys": "^2.0.0",
+						"normalize-url": "^4.1.0",
+						"responselike": "^1.0.2"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+							"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+							"requires": {
+								"pump": "^3.0.0"
+							}
+						},
+						"lowercase-keys": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+							"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+						}
+					}
+				},
+				"decompress-response": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+					"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+					"requires": {
+						"mimic-response": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"got": {
+					"version": "9.6.0",
+					"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+					"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+					"requires": {
+						"@sindresorhus/is": "^0.14.0",
+						"@szmarczak/http-timer": "^1.1.2",
+						"cacheable-request": "^6.0.0",
+						"decompress-response": "^3.3.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^4.1.0",
+						"lowercase-keys": "^1.0.1",
+						"mimic-response": "^1.0.1",
+						"p-cancelable": "^1.0.0",
+						"to-readable-stream": "^1.0.0",
+						"url-parse-lax": "^3.0.0"
+					}
+				},
+				"json-buffer": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+					"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+				},
+				"keyv": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+					"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+					"requires": {
+						"json-buffer": "3.0.0"
+					}
+				},
+				"lowercase-keys": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+					"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+				},
+				"mimic-response": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+				},
+				"p-cancelable": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+					"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+				},
+				"responselike": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+					"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+					"requires": {
+						"lowercase-keys": "^1.0.0"
+					}
+				},
+				"to-readable-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+					"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
+				}
 			}
 		},
 		"pako": {
@@ -6747,8 +6747,7 @@
 		"prepend-http": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-			"dev": true
+			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 		},
 		"pretty-ms": {
 			"version": "5.1.0",
@@ -6804,6 +6803,12 @@
 				"react-is": "^16.8.1"
 			}
 		},
+		"propagate": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+			"integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+			"dev": true
+		},
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -6834,7 +6839,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -6910,7 +6914,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dev": true,
 			"requires": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -7122,7 +7125,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
 			"integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
-			"dev": true,
 			"requires": {
 				"rc": "^1.2.8",
 				"safe-buffer": "^5.0.1"
@@ -7132,7 +7134,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
 			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
-			"dev": true,
 			"requires": {
 				"rc": "^1.2.8"
 			}
@@ -7258,15 +7259,6 @@
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
 		},
-		"responselike": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-			"dev": true,
-			"requires": {
-				"lowercase-keys": "^1.0.0"
-			}
-		},
 		"restore-cursor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -7350,8 +7342,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -7382,8 +7373,7 @@
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 		},
 		"semver-compare": {
 			"version": "1.0.0",
@@ -7395,7 +7385,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
 			"integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
-			"dev": true,
 			"requires": {
 				"semver": "^6.3.0"
 			}
@@ -7490,8 +7479,7 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"sinon": {
 			"version": "7.5.0",
@@ -7902,7 +7890,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
 			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-			"dev": true,
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -7912,26 +7899,22 @@
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 				},
 				"strip-ansi": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
 					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.0"
 					}
@@ -7971,7 +7954,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^4.1.0"
 			}
@@ -8006,8 +7988,7 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"supertap": {
 			"version": "1.0.0",
@@ -8055,7 +8036,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 			"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0"
 			}
@@ -8141,8 +8121,7 @@
 		"term-size": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.1.1.tgz",
-			"integrity": "sha512-UqvQSch04R+69g4RDhrslmGvGL3ucDRX/U+snYW0Mab4uCAyKSndUksaoqlJ81QKSpRnIsuOYQCbC2ZWx2896A==",
-			"dev": true
+			"integrity": "sha512-UqvQSch04R+69g4RDhrslmGvGL3ucDRX/U+snYW0Mab4uCAyKSndUksaoqlJ81QKSpRnIsuOYQCbC2ZWx2896A=="
 		},
 		"terser": {
 			"version": "4.4.3",
@@ -8324,12 +8303,6 @@
 				}
 			}
 		},
-		"to-readable-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-			"dev": true
-		},
 		"to-regex": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -8399,8 +8372,7 @@
 		"type-fest": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-			"dev": true
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
 		},
 		"typedarray": {
 			"version": "0.0.6",
@@ -8412,7 +8384,6 @@
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
 			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-			"dev": true,
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
@@ -8511,7 +8482,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
 			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-			"dev": true,
 			"requires": {
 				"crypto-random-string": "^2.0.0"
 			}
@@ -8589,7 +8559,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.0.0.tgz",
 			"integrity": "sha512-p9zf71hWt5GVXM4iEBujpUgx8mK9AWiCCapEJm/O1z5ntCim83Z1ATqzZFBHFYqx03laMqv8LiDgs/7ikXjf/g==",
-			"dev": true,
 			"requires": {
 				"boxen": "^4.2.0",
 				"chalk": "^3.0.0",
@@ -8609,7 +8578,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
 					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
@@ -8654,7 +8622,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"dev": true,
 			"requires": {
 				"prepend-http": "^2.0.0"
 			}
@@ -9874,7 +9841,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
 			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-			"dev": true,
 			"requires": {
 				"string-width": "^4.0.0"
 			}
@@ -9951,8 +9917,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "1.0.3",
@@ -9967,7 +9932,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
 			"integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
-			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4",
 				"is-typedarray": "^1.0.0",
@@ -9978,8 +9942,7 @@
 		"xdg-basedir": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-			"dev": true
+			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,11 @@
 		"prepare": "npm t && webpack",
 		"test": "standard && nyc ava"
 	},
-	"dependencies": {},
+	"dependencies": {
+		"update-notifier": "^4.0.0"
+	},
 	"devDependencies": {
+		"abort-controller": "^3.0.0",
 		"ava": "^2.4.0",
 		"boxen": "^4.1.0",
 		"chalk": "^2.4.2",
@@ -25,13 +28,13 @@
 		"diffy": "^2.1.0",
 		"husky": "^3.0.5",
 		"minimist": "^1.2.0",
+		"nock": "^11.7.2",
 		"node-fetch": "^2.6.0",
 		"nyc": "^14.1.1",
 		"prompts": "^2.2.1",
 		"sinon": "^7.5.0",
 		"standard": "^13.1.0",
 		"term-size": "^2.1.0",
-		"update-notifier": "^4.0.0",
 		"webpack": "^4.41.4",
 		"webpack-cli": "^3.3.10",
 		"word-wrap": "^1.2.3"

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -1,0 +1,14 @@
+const { AbortController } = require('abort-controller')
+const { default: nf } = require('node-fetch')
+const { TIMEOUT } = require('../constants')
+
+module.exports = async function fetch (url, opts) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => {
+    controller.abort()
+  }, TIMEOUT)
+  return nf(url, Object.assign({}, opts, { signal: controller.signal }))
+    .finally(() => {
+      clearTimeout(timeout)
+    })
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,5 +1,5 @@
 const qs = require('querystring')
-const fetch = require('node-fetch').default
+const fetch = require('./fetch')
 const { API_HOST, ROUTES } = require('../constants')
 
 function Api ({ config }) {

--- a/src/bin.js
+++ b/src/bin.js
@@ -2,3 +2,7 @@
 // and is meant for testing (since the bin.js in the parent dir
 // directly calls the minified bundle)
 require('.')()
+
+try {
+  require('update-notifier')({ pkg: require('../package.json') }).notify()
+} catch (_) {}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 module.exports = {
   INTERVAL: 5000,
+  TIMEOUT: 10000,
   API_HOST: 'https://api.flossbank.com',
   ROUTES: {
     START: 'session/start',

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,6 @@ const Ui = require('./ui')
 const Pm = require('./pm')
 const Args = require('./args')
 const Alias = require('./util/alias')
-const updateNotifier = require('update-notifier')
-const pkg = require('../package.json')
 
 module.exports = async () => {
   const config = new Config()
@@ -58,6 +56,4 @@ module.exports = async () => {
   adsPm((e, stdout, stderr) => {
     ui.setPmOutput(e, stdout, stderr)
   })
-
-  updateNotifier({ pkg }).notify()
 }


### PR DESCRIPTION
webpack was having problems with update-notifier (`is-ci` among others). realized we don't need that bundled and causing us trouble.

added timeout for all api calls of 10s; ideally this is a lower number but i'm not sure how feasible that is.

next steps:
- falling back to "natural npm" for api timeouts and empty ad fetch responses