### PR TITLE
fck u webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -680,6 +680,16 @@
 			"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
 			"dev": true
 		},
+		"aggregate-error": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+			"integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+			"dev": true,
+			"requires": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			}
+		},
 		"ajv": {
 			"version": "6.10.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -3939,6 +3949,15 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
+		"fs-minipass": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"dev": true,
+			"requires": {
+				"minipass": "^3.0.0"
+			}
+		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -5015,6 +5034,33 @@
 				"handlebars": "^4.1.2"
 			}
 		},
+		"jest-worker": {
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+			"dev": true,
+			"requires": {
+				"merge-stream": "^2.0.0",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -5434,6 +5480,12 @@
 				}
 			}
 		},
+		"merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
+		},
 		"merge2": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
@@ -5508,6 +5560,50 @@
 					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 					"dev": true
 				}
+			}
+		},
+		"minipass": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+			"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+			"dev": true,
+			"requires": {
+				"yallist": "^4.0.0"
+			},
+			"dependencies": {
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
+				}
+			}
+		},
+		"minipass-collect": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+			"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+			"dev": true,
+			"requires": {
+				"minipass": "^3.0.0"
+			}
+		},
+		"minipass-flush": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+			"dev": true,
+			"requires": {
+				"minipass": "^3.0.0"
+			}
+		},
+		"minipass-pipeline": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
+			"integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+			"dev": true,
+			"requires": {
+				"minipass": "^3.0.0"
 			}
 		},
 		"mississippi": {
@@ -8124,9 +8220,9 @@
 			"integrity": "sha512-UqvQSch04R+69g4RDhrslmGvGL3ucDRX/U+snYW0Mab4uCAyKSndUksaoqlJ81QKSpRnIsuOYQCbC2ZWx2896A=="
 		},
 		"terser": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.4.3.tgz",
-			"integrity": "sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==",
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
+			"integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -8143,26 +8239,106 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-			"integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.2.tgz",
+			"integrity": "sha512-SmvB/6gtEPv+CJ88MH5zDOsZdKXPS/Uzv2//e90+wM1IHFUhsguPKEILgzqrM1nQ4acRXN/SV4Obr55SXC+0oA==",
 			"dev": true,
 			"requires": {
-				"cacache": "^12.0.2",
-				"find-cache-dir": "^2.1.0",
-				"is-wsl": "^1.1.0",
-				"schema-utils": "^1.0.0",
+				"cacache": "^13.0.1",
+				"find-cache-dir": "^3.2.0",
+				"jest-worker": "^24.9.0",
+				"schema-utils": "^2.6.1",
 				"serialize-javascript": "^2.1.2",
 				"source-map": "^0.6.1",
-				"terser": "^4.1.2",
-				"webpack-sources": "^1.4.0",
-				"worker-farm": "^1.7.0"
+				"terser": "^4.4.3",
+				"webpack-sources": "^1.4.3"
 			},
 			"dependencies": {
+				"cacache": {
+					"version": "13.0.1",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
+					"integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.2",
+						"figgy-pudding": "^3.5.1",
+						"fs-minipass": "^2.0.0",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.2.2",
+						"infer-owner": "^1.0.4",
+						"lru-cache": "^5.1.1",
+						"minipass": "^3.0.0",
+						"minipass-collect": "^1.0.2",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.2",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"p-map": "^3.0.0",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.7.1",
+						"ssri": "^7.0.0",
+						"unique-filename": "^1.1.1"
+					}
+				},
+				"find-cache-dir": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+					"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^3.0.0",
+						"pkg-dir": "^4.1.0"
+					}
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"p-map": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+					"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"schema-utils": {
+					"version": "2.6.4",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+					"integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
+					}
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"ssri": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
+					"integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"minipass": "^3.1.1"
+					}
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 					"dev": true
 				}
 			}
@@ -9604,6 +9780,29 @@
 						"regex-not": "^1.0.0",
 						"snapdragon": "^0.8.1",
 						"to-regex": "^3.0.2"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"terser-webpack-plugin": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+					"integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+					"dev": true,
+					"requires": {
+						"cacache": "^12.0.2",
+						"find-cache-dir": "^2.1.0",
+						"is-wsl": "^1.1.0",
+						"schema-utils": "^1.0.0",
+						"serialize-javascript": "^2.1.2",
+						"source-map": "^0.6.1",
+						"terser": "^4.1.2",
+						"webpack-sources": "^1.4.0",
+						"worker-farm": "^1.7.0"
 					}
 				},
 				"to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"sinon": "^7.5.0",
 		"standard": "^13.1.0",
 		"term-size": "^2.1.0",
+		"terser-webpack-plugin": "^2.3.2",
 		"webpack": "^4.41.4",
 		"webpack-cli": "^3.3.10",
 		"word-wrap": "^1.2.3"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const TerserPlugin = require('terser-webpack-plugin')
 
 module.exports = {
   mode: 'production',
@@ -7,6 +8,18 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'flossbank.bundle.js',
     libraryTarget: 'commonjs2'
+  },
+  optimization: {
+    // concatenateModules: true breaks AbortSignal (node-fetch)
+    concatenateModules: false,
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          // keep_classnames: false breaks AbortSignal (node-fetch)
+          keep_classnames: true
+        }
+      })
+    ]
   },
   target: 'node'
 }


### PR DESCRIPTION
previous pr #26 caused some problems (need more unit tests / integ tests!) in the production build. 

what would happen is every time `fetch` was called, it would try to configure it to use the `AbortSignal` from `AbortController` (this is how timeouts are signaled in by-the-spec fetch). node-fetch currently (but will drop in v3) checks the constructor.name property of the `signal` you pass in. if it's not `instanceof AbortSignal` you're fcked and it throws. 

during production builds, webpack was uglifying the constructor name to be `i`. so had to turn that off. things are still uglified, it's just that class names are kept. the other issue was that during build, when webpack scoops up all the node modules and bundles everything together, it does a weird thing to maintain healthy name spaces; it will say "this exported class AbortSignal is from module `abort-controller` so we will rename it to `abort_controller_AbortSignal` -- we will preserve "AbortSignal" in the name bc you chose not to mangle class names". which of course caused node-fetch to throw up again. 

looked around for node-fetch alternatives but everything was either homemade or was `got` which doesn't webpack well. so opted to turn off `concatenateModules` in webpack; downside is webpack will compile things a little differently (using IIFEs) and the word on the street is instantiating those classes will be a tad slower. not noticeably as far as i can tell.

also, the reason the version commit keeps ending up in my PRs is because I forget to `git push` after `npm publish` (bc `npm version patch` actually commits "0.0.x" with the package.json change). so to be clear, i didn't publish these changes already. when i do it will be 0.0.8.