### PR TITLE
Add manual pass-through mode and pass-through when there are no ads

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -17,6 +17,7 @@ Api.prototype.getApiKey = function getApiKey () {
 
 Api.prototype.setTopLevelPackages = function setTopLevelPackages (pkgs) {
   this.packages = pkgs
+  return this
 }
 
 Api.prototype.fetchAd = async function fetchAd () {
@@ -47,6 +48,7 @@ Api.prototype.fetchAdBatch = async function fetchAdBatch () {
     debug('could not fetch ads: %O', e)
   }
   this.unseen.push(...ads)
+  return this.unseen.length
 }
 
 Api.prototype.sendAuthEmail = async function sendAuthEmail (email) {


### PR DESCRIPTION
- added `FLOSSBANK_DISABLE` env flag to let people skip our entire flow
- changed logic to get initial ad batch right before kicking off the package manager so that we can choose then to use pass-through mode or ads mode

gif of installing react-native after i purposefully mangled our API url (sorry didn't realize react-native takes 60s to install):
![passthru](https://user-images.githubusercontent.com/2707340/73306627-78dde600-41d1-11ea-80a4-15f54c571df1.gif)

gif of installing sodium-native with ads and then manually disabling floss:
![manual_passthru](https://user-images.githubusercontent.com/2707340/73306648-84c9a800-41d1-11ea-98b4-4a95a50646ba.gif)

tldr is that pass-through mode is indistinguishable from normal `npm` use
