### PR TITLE
Implement toggle functionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,7 @@ module.exports = async () => {
             flossbankVersion: version
           }
         })
+        process.exit()
       } catch (e) {
         debug('failed to complete session: %O', e)
       }
@@ -115,8 +116,12 @@ module.exports = async () => {
     .startAds()
 
   debug('running package manager with ads')
-  adsPm((e, stdout, stderr) => {
-    debug('package manager execution complete')
-    ui.setPmOutput(e, stdout, stderr)
+  adsPm((err, { stdout, stderr, exit, code } = {}) => {
+    if (exit) {
+      debug('package manager execution complete')
+      ui.setPmDone(code)
+    } else {
+      ui.setPmOutput(err, stdout, stderr)
+    }
   })
 }

--- a/src/pm/npm.js
+++ b/src/pm/npm.js
@@ -1,12 +1,20 @@
+const { supportsColor } = require('chalk')
 const { spawn, execFile } = require('child_process')
 const parseArgs = require('minimist')
 const readPackageJson = require('../util/readPackageJson')
 
-exports.start = async function ({ silent }, done) {
+exports.start = async function ({ silent }, cb) {
   if (!silent) {
     return spawn('npm', process.argv.slice(2), { stdio: 'inherit' })
   }
-  return execFile('npm', process.argv.slice(2), done)
+  if (supportsColor) {
+    process.env.FORCE_COLOR = 3
+  }
+  const child = spawn('npm', process.argv.slice(2))
+  child.on('error', (err) => cb(err))
+  child.on('exit', (code) => cb(null, { exit: true, code }))
+  child.stdout.on('data', (chunk) => cb(null, { stdout: chunk }))
+  child.stderr.on('data', (chunk) => cb(null, { stderr: chunk }))
 }
 
 exports.isSupportedVerb = function (cmd) {


### PR DESCRIPTION
npm doesn't emit any output until after it's downloaded everything, so it's a bit sparse; added a spinner to potentially help with the boredom. yarn emits output immediately and in realtime, so a very nice experience there. ads are paused while package manager output is visible.

example npm install where output is >1 page and end result is error:
![toggle_long_errors_npm](https://user-images.githubusercontent.com/2707340/75647460-e54d6a00-5c01-11ea-9b07-c2213083ff47.gif)

example yarn output
![toggle_yarn](https://user-images.githubusercontent.com/2707340/75647467-ec747800-5c01-11ea-87ba-6d31dd0c1f44.gif)
