### PR TITLE
Implement runlog

### DIFF
--- a/ci/validateInstall.js
+++ b/ci/validateInstall.js
@@ -7,6 +7,6 @@ const output = readFileSync('./ci/install_log.txt', encoding).split(os.EOL)
 
 assert.ok(output.find(line => line.includes('flossbank running package manager with ads')))
 assert.ok(output.find(line => line.includes('flossbank showing ad')))
-assert.ok(output.find(line => line.includes('flossbank completing session with these ad ids')))
+assert.ok(output.find(line => line.includes('flossbank seenAdIds')))
 
 console.log('Installation with ads validated')

--- a/package-lock.json
+++ b/package-lock.json
@@ -8214,6 +8214,25 @@
 			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
 			"dev": true
 		},
+		"temp-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+			"dev": true
+		},
+		"temp-write": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-4.0.0.tgz",
+			"integrity": "sha512-HIeWmj77uOOHb0QX7siN3OtwV3CTntquin6TNVg6SHOqCP3hYKmox90eeFOGaY1MqJ9WYDDjkyZrW6qS5AWpbw==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.15",
+				"is-stream": "^2.0.0",
+				"make-dir": "^3.0.0",
+				"temp-dir": "^1.0.0",
+				"uuid": "^3.3.2"
+			}
+		},
 		"term-size": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"prompts": "^2.2.1",
 		"sinon": "^7.5.0",
 		"standard": "^13.1.0",
+		"temp-write": "^4.0.0",
 		"term-size": "^2.1.0",
 		"terser-webpack-plugin": "^2.3.2",
 		"webpack": "^4.41.4",

--- a/src/args/runlog.js
+++ b/src/args/runlog.js
@@ -1,0 +1,3 @@
+module.exports = async ({ config }) => {
+  console.log(config.getLastRunlog())
+}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,7 +2,9 @@ const Conf = require('conf')
 const path = require('path')
 const {
   PROJECT_NAME,
-  CONFIG_API_KEY
+  CONFIG_API_KEY,
+  CONFIG_ALIASES,
+  CONFIG_LAST_RUNLOG
 } = require('../constants')
 
 function Config () {
@@ -17,16 +19,16 @@ Config.prototype.getPath = function getPath () {
 
 Config.prototype.addAlias = function addAlias (cmd, alias) {
   const existingAliases = this.getAliases() || {}
-  return this.conf.set('aliases', Object.assign({}, existingAliases, { [cmd]: alias }))
+  return this.conf.set(CONFIG_ALIASES, Object.assign({}, existingAliases, { [cmd]: alias }))
 }
 
 Config.prototype.removeAlias = function removeAlias (cmd, unalias) {
   const existingAliases = this.getAliases() || {}
-  return this.conf.set('aliases', Object.assign({}, existingAliases, { [cmd]: unalias }))
+  return this.conf.set(CONFIG_ALIASES, Object.assign({}, existingAliases, { [cmd]: unalias }))
 }
 
 Config.prototype.getAliases = function getAliases () {
-  return this.conf.get('aliases')
+  return this.conf.get(CONFIG_ALIASES)
 }
 
 Config.prototype.getApiKey = function getApiKey () {
@@ -35,6 +37,14 @@ Config.prototype.getApiKey = function getApiKey () {
 
 Config.prototype.setApiKey = async function setApiKey (apiKey) {
   return this.conf.set(CONFIG_API_KEY, apiKey)
+}
+
+Config.prototype.setLastRunlog = function setLastRunlog (logpath) {
+  return this.conf.set(CONFIG_LAST_RUNLOG, logpath)
+}
+
+Config.prototype.getLastRunlog = function getLastRunlog (logpath) {
+  return this.conf.get(CONFIG_LAST_RUNLOG, logpath)
 }
 
 module.exports = Config

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,10 +7,12 @@ module.exports = {
     COMPLETE: 'session/complete',
     SEND_AUTH: 'user/register'
   },
-  SUPPORTED_ARGS: ['help', 'version', 'auth', 'install', 'uninstall', 'source'],
+  SUPPORTED_ARGS: ['help', 'version', 'auth', 'install', 'uninstall', 'source', 'runlog'],
   DEFAULT_CONFIG: {},
   PROJECT_NAME: 'flossbank',
   CONFIG_API_KEY: 'apiKey',
+  CONFIG_ALIASES: 'aliases',
+  CONFIG_LAST_RUNLOG: 'lastRunlog',
   SHEBANG: '#!/usr/bin/env bash',
   ALIAS_FILE: 'flossbank_aliases.sh',
   SUPPORTED_PMS: ['npm', 'yarn'],

--- a/src/util/readPackageJson.js
+++ b/src/util/readPackageJson.js
@@ -1,7 +1,6 @@
 const { readFile } = require('fs')
 const { promisify } = require('util')
 const path = require('path')
-const debug = require('debug')('flossbank')
 
 const readFileAsync = promisify(readFile)
 
@@ -15,9 +14,7 @@ module.exports = async () => {
       'utf8'
     )
     packageJson = JSON.parse(packageJsonFile) || DEFAULT_PKG
-  } catch (e) {
-    debug('could not read package json: %O', e)
-  }
+  } catch (_) {}
   const deps = []
   for (const pkgName in packageJson.dependencies) {
     deps.push(`${pkgName}@${packageJson.dependencies[pkgName]}`)

--- a/src/util/runlog.js
+++ b/src/util/runlog.js
@@ -1,0 +1,64 @@
+const keys = {
+  FB_VERSION: 'fbVersion',
+  ARGUMENTS: 'arguments',
+  SUPPORTED_PM: 'supportedPm',
+  HAVE_API_KEY: 'haveApiKey',
+  AUTH_FLOW_FAILED: 'authFlowFailed',
+  INITIAL_AD_BATCH_SIZE: 'initialAdBatchSize',
+  PM_CMD: 'pmCmd',
+  SESSION_COMPLETE_DATA: 'sessionCompleteData',
+  SEEN_AD_IDS: 'seenAdIds',
+  EXIT_REASON: 'exitReason',
+  PASSTHROUGH_MODE: 'passthrough',
+  MANUALLY_DISABLED: 'manuallyDisabled'
+}
+
+// to get stringified errors
+function replaceErrors (_, val) {
+  if (val instanceof Error) {
+    const error = {}
+    Object.getOwnPropertyNames(val).forEach((prop) => {
+      error[prop] = val[prop]
+    })
+    return error
+  }
+  return val
+}
+
+class Runlog {
+  constructor ({ config, debug, tempWriter }) {
+    this.records = { errors: [] }
+    this.config = config
+    this.debugger = debug
+    this.tempWriter = tempWriter
+    this.keys = keys
+  }
+
+  get enabled () {
+    return this.debugger.enabled
+  }
+
+  record (key, val, silent) {
+    this.records[key] = val
+    if (!silent) this.debug(`${key}: %O`, val)
+  }
+
+  error (msg, err) {
+    this.debug(msg, err)
+    this.records.errors.push(err)
+  }
+
+  debug (...args) {
+    this.debugger(...args)
+  }
+
+  async write (reason) {
+    if (!this.enabled) return
+    this.record(keys.EXIT_REASON, reason, true)
+    const path = await this.tempWriter.write(JSON.stringify(this.records, replaceErrors))
+    this.config.setLastRunlog(path)
+  }
+}
+
+exports.keys = keys
+exports.Runlog = Runlog

--- a/src/util/temp.js
+++ b/src/util/temp.js
@@ -1,0 +1,8 @@
+const tempWrite = require('temp-write')
+
+module.exports = class TempWriter {
+  async write (something) {
+    const path = await tempWrite(something)
+    return path
+  }
+}

--- a/test/util/runlog.test.js
+++ b/test/util/runlog.test.js
@@ -1,0 +1,61 @@
+const test = require('ava')
+const sinon = require('sinon')
+const debug = require('debug')
+const { Runlog } = require('../../src/util/runlog')
+
+test.beforeEach((t) => {
+  t.context.config = {
+    setLastRunlog: sinon.stub()
+  }
+  t.context.tempWriter = {
+    write: sinon.stub().returns('/abc')
+  }
+  t.context.debug = debug('flossbank')
+  t.context.debug.log = () => {}
+  t.context.runlog = new Runlog({
+    config: t.context.config,
+    debug: t.context.debug,
+    tempWriter: t.context.tempWriter
+  })
+})
+
+test('record | updates records', (t) => {
+  t.context.runlog.record('a', 'b')
+  t.is(t.context.runlog.records.a, 'b')
+})
+
+test('error | updates recorded errors', (t) => {
+  t.context.runlog.error('a', new Error('b'))
+  t.deepEqual(t.context.runlog.records.errors, [new Error('b')])
+})
+
+test('write | does nothing when disabled', async (t) => {
+  t.context.runlog.record('a', 'b')
+  await t.context.runlog.write()
+  t.true(t.context.config.setLastRunlog.notCalled)
+  t.true(t.context.tempWriter.write.notCalled)
+})
+
+test('write | updates config', async (t) => {
+  t.context.runlog.debugger.enabled = true
+  t.context.runlog.record('a', 'b')
+  await t.context.runlog.write()
+  t.true(t.context.config.setLastRunlog.calledOnce)
+  t.deepEqual(t.context.tempWriter.write.lastCall.args, [
+    JSON.stringify({ errors: [], a: 'b' })
+  ])
+})
+
+test('write | errors are preserved', async (t) => {
+  t.context.runlog.debugger.enabled = true
+  const error = new Error('b')
+  t.context.runlog.error('a', error)
+  await t.context.runlog.write()
+
+  const expectedErrors = [
+    { stack: error.stack, message: error.message }
+  ]
+  t.deepEqual(t.context.tempWriter.write.lastCall.args, [
+    JSON.stringify({ errors: expectedErrors })
+  ])
+})


### PR DESCRIPTION
implemented a runlog which will presently be used for integration test assertions, but may come in handy later on in troubleshooting situations. current integ tests run an installation-with-ads flow in debug mode and make assertions on the raw output lines; it makes more sense to collect important data in a machine-friendly format and make assertions there.

- wraps `debug` so no regression of features (`runlog.debug`)
- allows us to record certain data points during execution (`runlog.record`)
- non-fatal errors encountered during execution are collected and recorded (`runlog.error`)
- records are persisted in a temporary JSON file (`runlog.write`)
- the path to the last runlog is persisted in our config file
- a new command `flossbank runlog` returns the path to the last runlog (allowing `cat $(flossbank runlog) | jq` for example)
- nothing is written or logged if debug mode is not enabled `env.DEBUG != flossbank`

example runlog after a normal execution:

```json
{
  "errors": [],
  "fbVersion": "0.0.17",
  "arguments": {},
  "supportedPm": true,
  "pmCmd": "npm i",
  "haveApiKey": true,
  "initialAdBatchSize": 12,
  "passthrough": false,
  "sessionCompleteData": {
    "packages": [
      "core-js@^3.6.4",
      "fshash@0.0.15",
      "js-deep-equals@^2.1.1",
      "loose-envify@1.4.0",
      "object-assign@4.1.1"
    ],
    "registry": "https://registry.npmjs.org/",
    "language": "javascript",
    "metadata": {
      "packageManagerVersion": "npm@6.11.3",
      "flossbankVersion": "0.0.17"
    }
  },
  "seenAdIds": [
    "5e3b04ba7ca8796b782ce6b9_01E0BX70FSY3MJ43T4NA44J8JD_01E0BX70FW64SRQ81XC9CQDD98"
  ]
}
```

example runlog when an error happened during ad fetching:

```json
{
  "errors": [
    {
      "stack": "Error: did not receive ok response from api: 401\n    at Api.fetchAdBatch (/Users/squipet/os/flossbank/cli/src/api/index.js:40:24)\n    at processTicksAndRejections (internal/process/task_queues.js:93:5)\n    at async module.exports (/Users/squipet/os/flossbank/cli/src/index.js:79:26)",
      "message": "did not receive ok response from api: 401"
    }
  ],
  "fbVersion": "0.0.17",
  "arguments": {},
  "supportedPm": true,
  "pmCmd": "npm i",
  "haveApiKey": true,
  "initialAdBatchSize": 0,
  "passthrough": true
}
```