### PR TITLE
Add real auth check after API key is entered

### DIFF
--- a/ci/tests/_util.js
+++ b/ci/tests/_util.js
@@ -11,30 +11,30 @@ const rm = promisify(rimraf)
 const INTEG_TEST_KEY = 'cf667c9381f7792bfa772025ff8ee93b89d9a757e6732e87611a0c34b48357d1'
 const config = new Config()
 
-export function setIntegApiKey () {
+exports.setIntegApiKey = function setIntegApiKey () {
   return config.setApiKey(INTEG_TEST_KEY)
 }
 
-export function setInvalidApiKey () {
+exports.setInvalidApiKey = function setInvalidApiKey () {
   return config.setApiKey('very-invalid-api-key')
 }
 
-export function getBinPath () {
+exports.getBinPath = function getBinPath () {
   return path.resolve(process.cwd(), '../../', 'bin.js')
 }
 
-export async function deleteInstalledDeps (pythonDepDir) {
+exports.deleteInstalledDeps = async function deleteInstalledDeps (pythonDepDir) {
   return Promise.all([
     rm('node_modules'),
     rm(`${pythonDepDir}/*`)
   ])
 }
 
-export async function getNodeModules () {
+exports.getNodeModules = async function getNodeModules () {
   return ls('./node_modules/*').map(dir => dir.name)
 }
 
-export function resolvePythonDepDir () {
+exports.resolvePythonDepDir = function resolvePythonDepDir () {
   return new Promise((resolve, reject) => {
     execFile('python', ['-m', 'site', '--user-site'], (err, stdout) => {
       if (err) return reject(err)
@@ -43,30 +43,30 @@ export function resolvePythonDepDir () {
   })
 }
 
-export async function getPythonPackages (pythonDepDir) {
+exports.getPythonPackages = async function getPythonPackages (pythonDepDir) {
   return ls(`${pythonDepDir}/*`).map(dir => dir.name)
 }
 
-export function runFlossbank (args) {
+exports.runFlossbank = function runFlossbank (args) {
   return new Promise((resolve, reject) => {
-    execFile('node', [getBinPath()].concat(args), (err, stdout) => {
+    execFile('node', [exports.getBinPath()].concat(args), (err, stdout) => {
       if (err) return reject(err)
       resolve(stdout.trim())
     })
   })
 }
 
-export function getLastRunlog () {
+exports.getLastRunlog = function getLastRunlog () {
   return new Promise((resolve, reject) => {
-    execFile('node', [getBinPath(), 'runlog'], (err, stdout) => {
+    execFile('node', [exports.getBinPath(), 'runlog'], (err, stdout) => {
       if (err) return reject(err)
       if (!stdout) return reject(Error('no runlog found'))
-      readFileAsync(stdout.trim()).then((data) => resolve(JSON.parse(data)))
+      exports.readFileAsync(stdout.trim()).then((data) => resolve(JSON.parse(data)))
     })
   })
 }
 
-export function readFileAsync (...args) {
+exports.readFileAsync = function readFileAsync (...args) {
   return new Promise((resolve, reject) => {
     readFile(...args, (err, data) => {
       if (err) return reject(err)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,35 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@ava/babel-plugin-throws-helper": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-4.0.0.tgz",
-			"integrity": "sha512-3diBLIVBPPh3j4+hb5lo0I1D+S/O/VDJPI4Y502apBxmwEqjyXG4gTSPFUlm41sSZeZzMarT/Gzovw9kV7An0w==",
-			"dev": true
-		},
-		"@ava/babel-preset-stage-4": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-4.0.0.tgz",
-			"integrity": "sha512-lZEV1ZANzfzSYBU6WHSErsy7jLPbD1iIgAboASPMcKo7woVni5/5IKWeT0RxC8rY802MFktur3OKEw2JY1Tv2w==",
-			"dev": true,
-			"requires": {
-				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-				"@babel/plugin-proposal-dynamic-import": "^7.5.0",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-transform-dotall-regex": "^7.4.4",
-				"@babel/plugin-transform-modules-commonjs": "^7.5.0"
-			}
-		},
-		"@ava/babel-preset-transform-test-files": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-6.0.0.tgz",
-			"integrity": "sha512-8eKhFzZp7Qcq1VLfoC75ggGT8nQs9q8fIxltU47yCB7Wi7Y8Qf6oqY1Bm0z04fIec24vEgr0ENhDHEOUGVDqnA==",
-			"dev": true,
-			"requires": {
-				"@ava/babel-plugin-throws-helper": "^4.0.0",
-				"babel-plugin-espower": "^3.0.1"
-			}
-		},
 		"@babel/code-frame": {
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -40,36 +11,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
-			}
-		},
-		"@babel/core": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.7.tgz",
-			"integrity": "sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.7.7",
-				"@babel/helpers": "^7.7.4",
-				"@babel/parser": "^7.7.7",
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4",
-				"convert-source-map": "^1.7.0",
-				"debug": "^4.1.0",
-				"json5": "^2.1.0",
-				"lodash": "^4.17.13",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/generator": {
@@ -82,25 +23,6 @@
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
 				"source-map": "^0.5.0"
-			}
-		},
-		"@babel/helper-annotate-as-pure": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
-			"integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.7.4"
-			}
-		},
-		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
-			"integrity": "sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/helper-function-name": {
@@ -123,96 +45,12 @@
 				"@babel/types": "^7.7.4"
 			}
 		},
-		"@babel/helper-module-imports": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
-			"integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.7.4"
-			}
-		},
-		"@babel/helper-module-transforms": {
-			"version": "7.7.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
-			"integrity": "sha512-A7pSxyJf1gN5qXVcidwLWydjftUN878VkalhXX5iQDuGyiGK3sOrrKKHF4/A4fwHtnsotv/NipwAeLzY4KQPvw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.7.4",
-				"@babel/helper-simple-access": "^7.7.4",
-				"@babel/helper-split-export-declaration": "^7.7.4",
-				"@babel/template": "^7.7.4",
-				"@babel/types": "^7.7.4",
-				"lodash": "^4.17.13"
-			}
-		},
-		"@babel/helper-plugin-utils": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
-			"dev": true
-		},
-		"@babel/helper-regex": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-			"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.13"
-			}
-		},
-		"@babel/helper-remap-async-to-generator": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
-			"integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.7.4",
-				"@babel/helper-wrap-function": "^7.7.4",
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
-			}
-		},
-		"@babel/helper-simple-access": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
-			"integrity": "sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "^7.7.4",
-				"@babel/types": "^7.7.4"
-			}
-		},
 		"@babel/helper-split-export-declaration": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
 			"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.7.4"
-			}
-		},
-		"@babel/helper-wrap-function": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
-			"integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
-			}
-		},
-		"@babel/helpers": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
-			"integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
 				"@babel/types": "^7.7.4"
 			}
 		},
@@ -232,86 +70,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
 			"integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
 			"dev": true
-		},
-		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
-			"integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.7.4",
-				"@babel/plugin-syntax-async-generators": "^7.7.4"
-			}
-		},
-		"@babel/plugin-proposal-dynamic-import": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
-			"integrity": "sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-dynamic-import": "^7.7.4"
-			}
-		},
-		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
-			"integrity": "sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
-			}
-		},
-		"@babel/plugin-syntax-async-generators": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
-			"integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-dynamic-import": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
-			"integrity": "sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
-			"integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.7.tgz",
-			"integrity": "sha512-b4in+YlTeE/QmTgrllnb3bHA0HntYvjz8O3Mcbx75UBPJA2xhb5A8nle498VhxSXJHQefjtQxpnLPehDJ4TRlg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.7.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
-			"integrity": "sha512-9Cq4zTFExwFhQI6MT1aFxgqhIsMWQWDVwOgLzl7PTWJHsNaqFvklAU+Oz6AQLAS0dJKTwZSOCo20INwktxpi3Q==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-transforms": "^7.7.5",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-simple-access": "^7.7.4",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
-			}
 		},
 		"@babel/template": {
 			"version": "7.7.4",
@@ -460,9 +218,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.1.tgz",
-			"integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ==",
+			"version": "13.9.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.2.tgz",
+			"integrity": "sha512-bnoqK579sAYrQbp73wwglccjJ4sfRdKU7WNEZ5FW4K2U6Kc0/eZ5kvXG0JKsEKFB50zrFmfFt52/cvBbZa7eXg==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -743,15 +501,6 @@
 				"ansi-split": "^1.0.1"
 			}
 		},
-		"ansi-escapes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-			"integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
-			"dev": true,
-			"requires": {
-				"type-fest": "^0.8.1"
-			}
-		},
 		"ansi-regex": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -870,16 +619,16 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
-		"array-uniq": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
-			"integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
-			"dev": true
-		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true
+		},
+		"arrgv": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/arrgv/-/arrgv-1.0.2.tgz",
+			"integrity": "sha512-a4eg4yhp7mmruZDQFqVMlxNRFGi/i1r87pt8SDHy0/I8PqSXoUTlWZRdAZo0VXgvEARcujbtTk8kiZRi1uDGRw==",
 			"dev": true
 		},
 		"arrify": {
@@ -951,341 +700,212 @@
 			"dev": true
 		},
 		"ava": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/ava/-/ava-2.4.0.tgz",
-			"integrity": "sha512-CQWtzZZZeU2g4StojRv6MO9RIRi4sLxGSB9+3C3hv0ttUEG1tkJLTLyrBQeFS4WEeK12Z4ovE3f2iPVhSy8elA==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-3.5.0.tgz",
+			"integrity": "sha512-o+xq1RgAZrQ7GX5nddTNeYbUDogwlBoa/Hnt+b1ciCLLxSOj5U6ZFblLNBSKwHtP1X/8R06bmzvX47jmlVu9KQ==",
 			"dev": true,
 			"requires": {
-				"@ava/babel-preset-stage-4": "^4.0.0",
-				"@ava/babel-preset-transform-test-files": "^6.0.0",
-				"@babel/core": "^7.6.0",
-				"@babel/generator": "^7.6.0",
 				"@concordance/react": "^2.0.0",
-				"ansi-escapes": "^4.2.1",
-				"ansi-styles": "^4.1.0",
-				"arr-flatten": "^1.1.0",
-				"array-union": "^2.1.0",
-				"array-uniq": "^2.1.0",
+				"ansi-styles": "^4.2.1",
+				"arrgv": "^1.0.2",
 				"arrify": "^2.0.1",
-				"bluebird": "^3.5.5",
-				"chalk": "^2.4.2",
-				"chokidar": "^3.0.2",
-				"chunkd": "^1.0.0",
+				"chalk": "^3.0.0",
+				"chokidar": "^3.3.1",
+				"chunkd": "^2.0.1",
 				"ci-parallel-vars": "^1.0.0",
 				"clean-stack": "^2.2.0",
 				"clean-yaml-object": "^0.1.0",
 				"cli-cursor": "^3.1.0",
-				"cli-truncate": "^2.0.0",
+				"cli-truncate": "^2.1.0",
 				"code-excerpt": "^2.1.1",
-				"common-path-prefix": "^1.0.0",
+				"common-path-prefix": "^3.0.0",
 				"concordance": "^4.0.0",
-				"convert-source-map": "^1.6.0",
+				"convert-source-map": "^1.7.0",
 				"currently-unhandled": "^0.4.1",
 				"debug": "^4.1.1",
-				"del": "^4.1.1",
-				"dot-prop": "^5.1.0",
-				"emittery": "^0.4.1",
-				"empower-core": "^1.2.0",
+				"del": "^5.1.0",
+				"emittery": "^0.5.1",
 				"equal-length": "^1.0.0",
-				"escape-string-regexp": "^2.0.0",
-				"esm": "^3.2.25",
-				"figures": "^3.0.0",
-				"find-up": "^4.1.0",
-				"get-port": "^5.0.0",
-				"globby": "^10.0.1",
+				"figures": "^3.1.0",
+				"globby": "^11.0.0",
 				"ignore-by-default": "^1.0.0",
 				"import-local": "^3.0.2",
 				"indent-string": "^4.0.0",
 				"is-ci": "^2.0.0",
 				"is-error": "^2.2.2",
-				"is-observable": "^2.0.0",
 				"is-plain-object": "^3.0.0",
 				"is-promise": "^2.1.0",
 				"lodash": "^4.17.15",
-				"loud-rejection": "^2.1.0",
-				"make-dir": "^3.0.0",
-				"matcher": "^2.0.0",
+				"matcher": "^2.1.0",
 				"md5-hex": "^3.0.1",
-				"meow": "^5.0.0",
-				"micromatch": "^4.0.2",
 				"ms": "^2.1.2",
-				"observable-to-promise": "^1.0.0",
-				"ora": "^3.4.0",
-				"package-hash": "^4.0.0",
+				"ora": "^4.0.3",
+				"p-map": "^3.0.0",
+				"picomatch": "^2.2.1",
 				"pkg-conf": "^3.1.0",
-				"plur": "^3.1.1",
-				"pretty-ms": "^5.0.0",
-				"require-precompiled": "^0.1.0",
+				"plur": "^4.0.0",
+				"pretty-ms": "^6.0.0",
+				"read-pkg": "^5.2.0",
 				"resolve-cwd": "^3.0.0",
 				"slash": "^3.0.0",
-				"source-map-support": "^0.5.13",
-				"stack-utils": "^1.0.2",
-				"strip-ansi": "^5.2.0",
-				"strip-bom-buf": "^2.0.0",
+				"source-map-support": "^0.5.16",
+				"stack-utils": "^2.0.1",
+				"strip-ansi": "^6.0.0",
 				"supertap": "^1.0.0",
-				"supports-color": "^7.0.0",
+				"temp-dir": "^2.0.0",
 				"trim-off-newlines": "^1.0.1",
-				"trim-right": "^1.0.1",
-				"unique-temp-dir": "^1.0.0",
-				"update-notifier": "^3.0.1",
-				"write-file-atomic": "^3.0.0"
+				"update-notifier": "^4.1.0",
+				"write-file-atomic": "^3.0.1",
+				"yargs": "^15.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
-				"boxen": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
-					"integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
 					"dev": true,
 					"requires": {
-						"ansi-align": "^3.0.0",
-						"camelcase": "^5.3.1",
-						"chalk": "^2.4.2",
-						"cli-boxes": "^2.2.0",
-						"string-width": "^3.0.0",
-						"term-size": "^1.2.0",
-						"type-fest": "^0.3.0",
-						"widest-line": "^2.0.0"
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
 					}
 				},
 				"configstore": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
-					"integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+					"integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.0",
+						"dot-prop": "^5.2.0",
 						"graceful-fs": "^4.1.2",
-						"make-dir": "^1.0.0",
-						"unique-string": "^1.0.0",
-						"write-file-atomic": "^2.0.0",
-						"xdg-basedir": "^3.0.0"
-					},
-					"dependencies": {
-						"dot-prop": {
-							"version": "4.2.0",
-							"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-							"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-							"dev": true,
-							"requires": {
-								"is-obj": "^1.0.0"
-							}
-						},
-						"make-dir": {
-							"version": "1.3.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-							"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-							"dev": true,
-							"requires": {
-								"pify": "^3.0.0"
-							}
-						},
-						"write-file-atomic": {
-							"version": "2.4.3",
-							"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-							"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-							"dev": true,
-							"requires": {
-								"graceful-fs": "^4.1.11",
-								"imurmurhash": "^0.1.4",
-								"signal-exit": "^3.0.2"
-							}
-						}
+						"make-dir": "^3.0.0",
+						"unique-string": "^2.0.0",
+						"write-file-atomic": "^3.0.0",
+						"xdg-basedir": "^4.0.0"
 					}
 				},
-				"crypto-random-string": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-					"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-					"dev": true
+				"parse-json": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1",
+						"lines-and-columns": "^1.1.6"
+					}
 				},
-				"escape-string-regexp": {
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"temp-dir": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+					"integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
 					"dev": true
-				},
-				"global-dirs": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-					"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-					"dev": true,
-					"requires": {
-						"ini": "^1.3.4"
-					}
-				},
-				"is-installed-globally": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-					"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-					"dev": true,
-					"requires": {
-						"global-dirs": "^0.1.0",
-						"is-path-inside": "^1.0.0"
-					}
-				},
-				"is-npm": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
-					"integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
-					"dev": true
-				},
-				"is-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-					"dev": true
-				},
-				"is-path-inside": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-					"dev": true,
-					"requires": {
-						"path-is-inside": "^1.0.1"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				},
-				"semver-diff": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-					"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-					"dev": true,
-					"requires": {
-						"semver": "^5.0.3"
-					}
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"term-size": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-					"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-					"dev": true,
-					"requires": {
-						"execa": "^0.7.0"
-					}
 				},
 				"type-fest": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+					"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
 					"dev": true
 				},
-				"unique-string": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-					"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-					"dev": true,
-					"requires": {
-						"crypto-random-string": "^1.0.0"
-					}
-				},
 				"update-notifier": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
-					"integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.0.tgz",
+					"integrity": "sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==",
 					"dev": true,
 					"requires": {
-						"boxen": "^3.0.0",
-						"chalk": "^2.0.1",
-						"configstore": "^4.0.0",
+						"boxen": "^4.2.0",
+						"chalk": "^3.0.0",
+						"configstore": "^5.0.1",
 						"has-yarn": "^2.1.0",
 						"import-lazy": "^2.1.0",
 						"is-ci": "^2.0.0",
-						"is-installed-globally": "^0.1.0",
-						"is-npm": "^3.0.0",
+						"is-installed-globally": "^0.3.1",
+						"is-npm": "^4.0.0",
 						"is-yarn-global": "^0.3.0",
 						"latest-version": "^5.0.0",
-						"semver-diff": "^2.0.0",
-						"xdg-basedir": "^3.0.0"
+						"pupa": "^2.0.1",
+						"semver-diff": "^3.1.1",
+						"xdg-basedir": "^4.0.0"
 					}
 				},
-				"widest-line": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-					"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-							"dev": true,
-							"requires": {
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^4.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
-				"xdg-basedir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-					"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-					"dev": true
+				"yargs": {
+					"version": "15.3.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+					"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+					"dev": true,
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.1"
+					}
 				}
-			}
-		},
-		"babel-plugin-dynamic-import-node": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
-			"dev": true,
-			"requires": {
-				"object.assign": "^4.1.0"
-			}
-		},
-		"babel-plugin-espower": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-3.0.1.tgz",
-			"integrity": "sha512-Ms49U7VIAtQ/TtcqRbD6UBmJBUCSxiC3+zPc+eGqxKUIFO1lTshyEDRUjhoAbd2rWfwYf3cZ62oXozrd8W6J0A==",
-			"dev": true,
-			"requires": {
-				"@babel/generator": "^7.0.0",
-				"@babel/parser": "^7.0.0",
-				"call-matcher": "^1.0.0",
-				"core-js": "^2.0.0",
-				"espower-location-detector": "^1.0.0",
-				"espurify": "^1.6.0",
-				"estraverse": "^4.1.1"
 			}
 		},
 		"balanced-match": {
@@ -1702,24 +1322,6 @@
 				}
 			}
 		},
-		"call-matcher": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.1.0.tgz",
-			"integrity": "sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.0.0",
-				"deep-equal": "^1.0.0",
-				"espurify": "^1.6.0",
-				"estraverse": "^4.0.0"
-			}
-		},
-		"call-signature": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
-			"dev": true
-		},
 		"caller-callsite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -1748,25 +1350,6 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-		},
-		"camelcase-keys": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-			"dev": true,
-			"requires": {
-				"camelcase": "^4.1.0",
-				"map-obj": "^2.0.0",
-				"quick-lru": "^1.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				}
-			}
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -1858,9 +1441,9 @@
 			}
 		},
 		"chunkd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/chunkd/-/chunkd-1.0.0.tgz",
-			"integrity": "sha512-xx3Pb5VF9QaqCotolyZ1ywFBgyuJmu6+9dLiqBxgelEse9Xsr3yUlpoX3O4Oh11M00GT2kYMsRByTKIMJW2Lkg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/chunkd/-/chunkd-2.0.1.tgz",
+			"integrity": "sha512-7d58XsFmOq0j6el67Ug9mHf9ELUXsQXYJBkyxhH/k+6Ke0qXRnv0kbemx+Twc6fRJ07C49lcbdgm9FL1Ei/6SQ==",
 			"dev": true
 		},
 		"ci-info": {
@@ -2045,9 +1628,9 @@
 			"dev": true
 		},
 		"common-path-prefix": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
-			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+			"integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
 			"dev": true
 		},
 		"commondir": {
@@ -2211,12 +1794,6 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-			"dev": true
-		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2303,17 +1880,6 @@
 				"sha.js": "^2.4.8"
 			}
 		},
-		"cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
-			"requires": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			}
-		},
 		"crypto-browserify": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -2392,43 +1958,11 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"decamelize-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-			"dev": true,
-			"requires": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			},
-			"dependencies": {
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
-				}
-			}
-		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
-		},
-		"deep-equal": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-			"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-			"dev": true,
-			"requires": {
-				"is-arguments": "^1.0.4",
-				"is-date-object": "^1.0.1",
-				"is-regex": "^1.0.4",
-				"object-is": "^1.0.1",
-				"object-keys": "^1.1.1",
-				"regexp.prototype.flags": "^1.2.0"
-			}
 		},
 		"deep-extend": {
 			"version": "0.6.0",
@@ -2535,63 +2069,35 @@
 			}
 		},
 		"del": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
-			"integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
+			"integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
 			"dev": true,
 			"requires": {
-				"@types/glob": "^7.1.1",
-				"globby": "^6.1.0",
-				"is-path-cwd": "^2.0.0",
-				"is-path-in-cwd": "^2.0.0",
-				"p-map": "^2.0.0",
-				"pify": "^4.0.1",
-				"rimraf": "^2.6.3"
+				"globby": "^10.0.1",
+				"graceful-fs": "^4.2.2",
+				"is-glob": "^4.0.1",
+				"is-path-cwd": "^2.2.0",
+				"is-path-inside": "^3.0.1",
+				"p-map": "^3.0.0",
+				"rimraf": "^3.0.0",
+				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"array-union": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-					"dev": true,
-					"requires": {
-						"array-uniq": "^1.0.1"
-					}
-				},
-				"array-uniq": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-					"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-					"dev": true
-				},
 				"globby": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"version": "10.0.2",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+					"integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
 					"dev": true,
 					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
-						}
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
+						"@types/glob": "^7.1.1",
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.0.3",
+						"glob": "^7.1.3",
+						"ignore": "^5.1.1",
+						"merge2": "^1.2.3",
+						"slash": "^3.0.0"
 					}
 				}
 			}
@@ -2704,9 +2210,9 @@
 			}
 		},
 		"emittery": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
-			"integrity": "sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.5.1.tgz",
+			"integrity": "sha512-sYZXNHH9PhTfs98ROEFVC3bLiR8KSqXQsEHIwZ9J6H0RaQObC3JYq4G8IvDd0b45/LxfGKYBpmaUN4LiKytaNw==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -2719,16 +2225,6 @@
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
 			"dev": true
-		},
-		"empower-core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-1.2.0.tgz",
-			"integrity": "sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==",
-			"dev": true,
-			"requires": {
-				"call-signature": "0.0.2",
-				"core-js": "^2.0.0"
-			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -2825,6 +2321,12 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
 			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true
+		},
+		"escape-goat": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+			"integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
 			"dev": true
 		},
 		"escape-string-regexp": {
@@ -3300,24 +2802,6 @@
 			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
 			"dev": true
 		},
-		"esm": {
-			"version": "3.2.25",
-			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-			"dev": true
-		},
-		"espower-location-detector": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
-			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
-			"dev": true,
-			"requires": {
-				"is-url": "^1.2.1",
-				"path-is-absolute": "^1.0.0",
-				"source-map": "^0.5.0",
-				"xtend": "^4.0.0"
-			}
-		},
 		"espree": {
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
@@ -3334,15 +2818,6 @@
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
-		},
-		"espurify": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
-			"integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.0.0"
-			}
 		},
 		"esquery": {
 			"version": "1.0.1",
@@ -3394,35 +2869,6 @@
 			"requires": {
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
-			}
-		},
-		"execa": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-			"dev": true,
-			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-					"dev": true
-				},
-				"is-stream": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-					"dev": true
-				}
 			}
 		},
 		"expand-brackets": {
@@ -3620,16 +3066,17 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
-			"integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
+			"integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.0",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.2"
+				"micromatch": "^4.0.2",
+				"picomatch": "^2.2.1"
 			}
 		},
 		"fast-json-stable-stringify": {
@@ -3645,12 +3092,12 @@
 			"dev": true
 		},
 		"fastq": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
-			"integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.1.tgz",
+			"integrity": "sha512-mpIH5sKYueh3YyeJwqtVo8sORi0CgtmkVbK6kZStpQlZBYQuTzG2CZ7idSiJuA7bY0SFCWUc5WIs+oYumGCQNw==",
 			"dev": true,
 			"requires": {
-				"reusify": "^1.0.0"
+				"reusify": "^1.0.4"
 			}
 		},
 		"figgy-pudding": {
@@ -3660,9 +3107,9 @@
 			"dev": true
 		},
 		"figures": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-			"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
@@ -4041,12 +3488,6 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
-		"get-port": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.0.tgz",
-			"integrity": "sha512-bjioH1E9bTQUvgaB6VycVy1QVbTZI41yTnF9qkZz6ixgy/uhCH6D63bKeZ6Code/07JYA61MeI94jSdHss8PNA==",
-			"dev": true
-		},
 		"get-stdin": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -4132,18 +3573,16 @@
 			"dev": true
 		},
 		"globby": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
-			"integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
+			"integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
 			"dev": true,
 			"requires": {
-				"@types/glob": "^7.1.1",
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.0.3",
-				"glob": "^7.1.3",
-				"ignore": "^5.1.1",
-				"merge2": "^1.2.3",
+				"fast-glob": "^3.1.1",
+				"ignore": "^5.1.4",
+				"merge2": "^1.3.0",
 				"slash": "^3.0.0"
 			}
 		},
@@ -4275,16 +3714,6 @@
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
-			}
-		},
-		"hasha": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
-			"integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
-			"dev": true,
-			"requires": {
-				"is-stream": "^2.0.0",
-				"type-fest": "^0.8.0"
 			}
 		},
 		"hmac-drbg": {
@@ -4631,9 +4060,9 @@
 			"dev": true
 		},
 		"irregular-plurals": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
-			"integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
+			"integrity": "sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==",
 			"dev": true
 		},
 		"is-accessor-descriptor": {
@@ -4655,12 +4084,6 @@
 					}
 				}
 			}
-		},
-		"is-arguments": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -4796,6 +4219,12 @@
 				}
 			}
 		},
+		"is-interactive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+			"dev": true
+		},
 		"is-npm": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
@@ -4812,40 +4241,16 @@
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
 		},
-		"is-observable": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.0.0.tgz",
-			"integrity": "sha512-fhBZv3eFKUbyHXZ1oHujdo2tZ+CNbdpdzzlENgCGZUC8keoGxUew2jYFLYcUB4qo7LDD03o4KK11m/QYD7kEjg==",
-			"dev": true
-		},
 		"is-path-cwd": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
 			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
 			"dev": true
 		},
-		"is-path-in-cwd": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
-			"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
-			"dev": true,
-			"requires": {
-				"is-path-inside": "^2.1.0"
-			}
-		},
 		"is-path-inside": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-			"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-			"dev": true,
-			"requires": {
-				"path-is-inside": "^1.0.2"
-			}
-		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+			"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
 			"dev": true
 		},
 		"is-plain-object": {
@@ -4897,18 +4302,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-		},
-		"is-url": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-			"dev": true
-		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -5159,15 +4552,6 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
-		"json5": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.0"
-			}
-		},
 		"jsx-ast-utils": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
@@ -5323,12 +4707,12 @@
 			"dev": true
 		},
 		"log-symbols": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1"
+				"chalk": "^2.4.2"
 			}
 		},
 		"lolex": {
@@ -5344,16 +4728,6 @@
 			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
-		},
-		"loud-rejection": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.2.0.tgz",
-			"integrity": "sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==",
-			"dev": true,
-			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.2"
 			}
 		},
 		"lru-cache": {
@@ -5418,12 +4792,6 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true
-		},
-		"map-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
 			"dev": true
 		},
 		"map-visit": {
@@ -5497,35 +4865,6 @@
 			"requires": {
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
-			}
-		},
-		"meow": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-			"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
-			"dev": true,
-			"requires": {
-				"camelcase-keys": "^4.0.0",
-				"decamelize-keys": "^1.0.0",
-				"loud-rejection": "^1.0.0",
-				"minimist-options": "^3.0.1",
-				"normalize-package-data": "^2.3.4",
-				"read-pkg-up": "^3.0.0",
-				"redent": "^2.0.0",
-				"trim-newlines": "^2.0.0",
-				"yargs-parser": "^10.0.0"
-			},
-			"dependencies": {
-				"loud-rejection": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-					"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-					"dev": true,
-					"requires": {
-						"currently-unhandled": "^0.4.1",
-						"signal-exit": "^3.0.0"
-					}
-				}
 			}
 		},
 		"merge-source-map": {
@@ -5608,24 +4947,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-		},
-		"minimist-options": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-			"dev": true,
-			"requires": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0"
-			},
-			"dependencies": {
-				"arrify": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-					"dev": true
-				}
-			}
 		},
 		"minipass": {
 			"version": "3.1.1",
@@ -6113,12 +5434,6 @@
 			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
 			"dev": true
 		},
-		"object-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-			"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
-			"dev": true
-		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -6207,16 +5522,6 @@
 				"has": "^1.0.3"
 			}
 		},
-		"observable-to-promise": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-1.0.0.tgz",
-			"integrity": "sha512-cqnGUrNsE6vdVDTPAX9/WeVzwy/z37vdxupdQXU8vgTXRFH72KCZiZga8aca2ulRPIeem8W3vW9rQHBwfIl2WA==",
-			"dev": true,
-			"requires": {
-				"is-observable": "^2.0.0",
-				"symbol-observable": "^1.0.4"
-			}
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6273,51 +5578,50 @@
 			}
 		},
 		"ora": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
-			"integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-4.0.3.tgz",
+			"integrity": "sha512-fnDebVFyz309A73cqCipVL1fBZewq4vwgSHfxh43vVy31mbyoQ8sCH3Oeaog/owYOs/lLlGVPCISQonTneg6Pg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.2",
-				"cli-cursor": "^2.1.0",
-				"cli-spinners": "^2.0.0",
-				"log-symbols": "^2.2.0",
-				"strip-ansi": "^5.2.0",
+				"chalk": "^3.0.0",
+				"cli-cursor": "^3.1.0",
+				"cli-spinners": "^2.2.0",
+				"is-interactive": "^1.0.0",
+				"log-symbols": "^3.0.0",
+				"mute-stream": "0.0.8",
+				"strip-ansi": "^6.0.0",
 				"wcwidth": "^1.0.1"
 			},
 			"dependencies": {
-				"cli-cursor": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^2.0.0"
-					}
-				},
-				"mimic-fn": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
-				"onetime": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "^1.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
 					}
 				},
-				"restore-cursor": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+				"mute-stream": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+					"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"onetime": "^2.0.0",
-						"signal-exit": "^3.0.2"
+						"ansi-regex": "^5.0.0"
 					}
 				}
 			}
@@ -6439,28 +5743,19 @@
 			}
 		},
 		"p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+			"dev": true,
+			"requires": {
+				"aggregate-error": "^3.0.0"
+			}
 		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
-		},
-		"package-hash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
-			"integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.15",
-				"hasha": "^5.0.0",
-				"lodash.flattendeep": "^4.4.0",
-				"release-zalgo": "^1.0.0"
-			}
 		},
 		"package-json": {
 			"version": "6.5.0",
@@ -6692,12 +5987,6 @@
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
-		"path-is-inside": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
-		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -6739,9 +6028,9 @@
 			}
 		},
 		"picomatch": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
-			"integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
 			"dev": true
 		},
 		"pify": {
@@ -6749,21 +6038,6 @@
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 			"dev": true
-		},
-		"pinkie": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-			"dev": true
-		},
-		"pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
-			"requires": {
-				"pinkie": "^2.0.0"
-			}
 		},
 		"pkg-conf": {
 			"version": "3.1.0",
@@ -6905,12 +6179,12 @@
 			}
 		},
 		"plur": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
-			"integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+			"integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
 			"dev": true,
 			"requires": {
-				"irregular-plurals": "^2.0.0"
+				"irregular-plurals": "^3.2.0"
 			}
 		},
 		"posix-character-classes": {
@@ -6931,9 +6205,9 @@
 			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 		},
 		"pretty-ms": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-5.1.0.tgz",
-			"integrity": "sha512-4gaK1skD2gwscCfkswYQRmddUb2GJZtzDGRjHWadVHtK/DIKFufa12MvES6/xu1tVbUYeia5bmLcwJtZJQUqnw==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-6.0.1.tgz",
+			"integrity": "sha512-ke4njoVmlotekHlHyCZ3wI/c5AMT8peuHs8rKJqekj/oR5G8lND2dVpicFlUz5cbZgE290vvkMuDwfj/OcW1kw==",
 			"dev": true,
 			"requires": {
 				"parse-ms": "^2.1.0"
@@ -7054,6 +6328,15 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"pupa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
+			"integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+			"dev": true,
+			"requires": {
+				"escape-goat": "^2.0.0"
+			}
+		},
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -7064,12 +6347,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-			"dev": true
-		},
-		"quick-lru": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
 			"dev": true
 		},
 		"randombytes": {
@@ -7136,67 +6413,6 @@
 				}
 			}
 		},
-		"read-pkg-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-			"dev": true,
-			"requires": {
-				"find-up": "^2.0.0",
-				"read-pkg": "^3.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				}
-			}
-		},
 		"readable-stream": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -7229,39 +6445,6 @@
 				"picomatch": "^2.0.7"
 			}
 		},
-		"redent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-			"dev": true,
-			"requires": {
-				"indent-string": "^3.0.0",
-				"strip-indent": "^2.0.0"
-			},
-			"dependencies": {
-				"indent-string": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
-				}
-			}
-		},
-		"regenerate": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-			"dev": true
-		},
-		"regenerate-unicode-properties": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
-			"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
-			"dev": true,
-			"requires": {
-				"regenerate": "^1.4.0"
-			}
-		},
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -7272,35 +6455,11 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"regexp.prototype.flags": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-			"integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
-			}
-		},
 		"regexpp": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
 			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
 			"dev": true
-		},
-		"regexpu-core": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
-			"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
-			"dev": true,
-			"requires": {
-				"regenerate": "^1.4.0",
-				"regenerate-unicode-properties": "^8.1.0",
-				"regjsgen": "^0.5.0",
-				"regjsparser": "^0.6.0",
-				"unicode-match-property-ecmascript": "^1.0.4",
-				"unicode-match-property-value-ecmascript": "^1.1.0"
-			}
 		},
 		"registry-auth-token": {
 			"version": "4.0.0",
@@ -7317,29 +6476,6 @@
 			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
 			"requires": {
 				"rc": "^1.2.8"
-			}
-		},
-		"regjsgen": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
-			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
-			"dev": true
-		},
-		"regjsparser": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
-			"integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
-			"dev": true,
-			"requires": {
-				"jsesc": "~0.5.0"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
-				}
 			}
 		},
 		"release-zalgo": {
@@ -7379,12 +6515,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true
-		},
-		"require-precompiled": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
-			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
 			"dev": true
 		},
 		"resolve": {
@@ -7984,10 +7114,21 @@
 			}
 		},
 		"stack-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
-			"dev": true
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.1.tgz",
+			"integrity": "sha512-BvBTnHGm8boe+HiJFqP19ywEsGlfQAKqW78pbfvUuzCbUuxPPUyLrH5dYFY+Xn9IpLY3b5ZmMcl8jAqXB4wddg==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
+				}
+			}
 		},
 		"standard": {
 			"version": "13.1.0",
@@ -8156,25 +7297,10 @@
 			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
 			"dev": true
 		},
-		"strip-bom-buf": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz",
-			"integrity": "sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==",
-			"dev": true,
-			"requires": {
-				"is-utf8": "^0.2.1"
-			}
-		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
-		},
-		"strip-indent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
 			"dev": true
 		},
 		"strip-json-comments": {
@@ -8231,12 +7357,6 @@
 			"requires": {
 				"has-flag": "^4.0.0"
 			}
-		},
-		"symbol-observable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-			"dev": true
 		},
 		"table": {
 			"version": "5.4.6",
@@ -8626,22 +7746,10 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"trim-newlines": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-			"dev": true
-		},
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
 			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-			"dev": true
-		},
-		"trim-right": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
 			"dev": true
 		},
 		"tslib": {
@@ -8710,40 +7818,6 @@
 				}
 			}
 		},
-		"uid2": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-			"dev": true
-		},
-		"unicode-canonical-property-names-ecmascript": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-			"dev": true
-		},
-		"unicode-match-property-ecmascript": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-			"dev": true,
-			"requires": {
-				"unicode-canonical-property-names-ecmascript": "^1.0.4",
-				"unicode-property-aliases-ecmascript": "^1.0.4"
-			}
-		},
-		"unicode-match-property-value-ecmascript": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
-			"dev": true
-		},
-		"unicode-property-aliases-ecmascript": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
-			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
-			"dev": true
-		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -8786,17 +7860,6 @@
 			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
 			"requires": {
 				"crypto-random-string": "^2.0.0"
-			}
-		},
-		"unique-temp-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
-			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
-			"dev": true,
-			"requires": {
-				"mkdirp": "^0.5.1",
-				"os-tmpdir": "^1.0.1",
-				"uid2": "0.0.3"
 			}
 		},
 		"unset-value": {
@@ -10363,20 +9426,13 @@
 			}
 		},
 		"yargs-parser": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-			"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+			"version": "18.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
+			"integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				}
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
 		"postuninstall": "node bin.js uninstall",
 		"prepare": "npm t && npm run build",
 		"build": "webpack",
-		"test": "standard && nyc ava --match=\"!*integ*\"",
-		"integ-tests": "ava -v --match=\"*integ*\""
+		"test": "standard && nyc ava --timeout=15s --match=\"!*integ*\"",
+		"integ-tests": "ava -v --timeout=1m --match=\"*integ*\""
 	},
 	"dependencies": {
 		"update-notifier": "^4.0.0"
 	},
 	"devDependencies": {
 		"abort-controller": "^3.0.0",
-		"ava": "^2.4.0",
+		"ava": "^3.5.0",
 		"boxen": "^4.1.0",
 		"chalk": "^2.4.2",
 		"ci-info": "^2.0.0",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -60,6 +60,19 @@ Api.prototype.sendAuthEmail = async function sendAuthEmail (email) {
   })
 }
 
+Api.prototype.checkAuth = async function checkAuth (email, apiKey) {
+  const [url, options] = this.createRequest(ROUTES.CHECK_AUTH, 'POST', { email, apiKey })
+
+  try {
+    const res = await fetch(url, options)
+    if (!res.ok) return false
+    return true
+  } catch (e) {
+    this.runlog.error('could not check auth: %O', e)
+    return false
+  }
+}
+
 Api.prototype.completeSession = async function completeSession (sessionData = {}) {
   const seenAdIds = this.seen.map(ad => ad.id)
   const [url, options] = this.createRequest(ROUTES.COMPLETE, 'POST', { seen: seenAdIds, ...sessionData })

--- a/src/args/auth.js
+++ b/src/args/auth.js
@@ -1,7 +1,8 @@
 module.exports = async ({ ui, config, api }) => {
   const apiKey = await ui.authenticate({
     haveApiKey: !!config.getApiKey(),
-    sendAuthEmail: api.sendAuthEmail.bind(api)
+    sendAuthEmail: api.sendAuthEmail.bind(api),
+    checkAuth: api.checkAuth.bind(api)
   })
   if (!apiKey) return
   config.setApiKey(apiKey)

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,7 +5,8 @@ module.exports = {
   ROUTES: {
     START: 'session/start',
     COMPLETE: 'session/complete',
-    SEND_AUTH: 'user/register'
+    SEND_AUTH: 'user/register',
+    CHECK_AUTH: 'user/check'
   },
   SUPPORTED_ARGS: ['help', 'version', 'auth', 'install', 'uninstall', 'runlog'],
   SOURCE_VARIANT_SHELL: 'shell',

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,11 @@ module.exports = async () => {
   }
 
   if (!apiKey) {
-    const newApiKey = await ui.authenticate({ haveApiKey: !!apiKey, sendAuthEmail: api.sendAuthEmail.bind(api) })
+    const newApiKey = await ui.authenticate({
+      haveApiKey: !!apiKey,
+      sendAuthEmail: api.sendAuthEmail.bind(api),
+      checkAuth: api.checkAuth.bind(api)
+    })
     if (!newApiKey) {
       runlog.record(keys.AUTH_FLOW_FAILED, true)
       runlog.record(keys.PASSTHROUGH_MODE, true)

--- a/src/ui/auth.js
+++ b/src/ui/auth.js
@@ -27,7 +27,7 @@ exports.getAuthToken = async function getAuthToken () {
 }
 
 exports.authenticationFailed = function authenticationFailed () {
-  console.log(`${chalk.red('✖')} ${chalk.white.bold('Authentication failed: invalid token')}`)
+  console.log(`${chalk.red('✖')} ${chalk.white.bold('Authentication failed: invalid token. Please try again or email support@flossbank.com for help.')}`)
 }
 
 exports.authenticationSucceeded = function authenticationSucceeded () {

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -145,7 +145,7 @@ Ui.prototype.showCompletion = async function showCompletion () {
   if (adsSummary) console.log(adsSummary)
 }
 
-Ui.prototype.authenticate = async function authenticate ({ haveApiKey, sendAuthEmail }) {
+Ui.prototype.authenticate = async function authenticate ({ haveApiKey, sendAuthEmail, checkAuth }) {
   if (haveApiKey) {
     const { shouldContinue } = await auth.confirm()
     if (!shouldContinue) return
@@ -172,7 +172,7 @@ Ui.prototype.authenticate = async function authenticate ({ haveApiKey, sendAuthE
     return
   }
   const { token } = await auth.getAuthToken()
-  if (!token || !auth.isTokenTolerable(token)) {
+  if (!token || !auth.isTokenTolerable(token) || !await checkAuth(email, token)) {
     this.runlog.debug('got bad token from authentication flow: %o', token)
     auth.authenticationFailed()
     return

--- a/test/ui/auth.test.js
+++ b/test/ui/auth.test.js
@@ -34,7 +34,7 @@ test('prompts', async (t) => {
 test('authenticationFailed', (t) => {
   auth.authenticationFailed()
   t.true(console.log.calledWith(
-    `${chalk.red('✖')} ${chalk.white.bold('Authentication failed: invalid token')}`
+    `${chalk.red('✖')} ${chalk.white.bold('Authentication failed: invalid token. Please try again or email support@flossbank.com for help.')}`
   ))
 })
 


### PR DESCRIPTION
- Upgraded ava to v3, which required more explicitly setting timeouts for long tests and using old style exports for utils
- Added call to /user/check (https://github.com/flossbank/fastify-api/pull/58) when API key is entered
- Updated auth failure message