### PR TITLE
Support ad-less sessions

### DIFF
--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -143,6 +143,7 @@ Ui.prototype.showCompletion = async function showCompletion () {
     process.stdout.write(this.pmOutput)
   }
   if (adsSummary) console.log(adsSummary)
+  this.sayGoodbye()
 }
 
 Ui.prototype.authenticate = async function authenticate ({ haveApiKey, sendAuthEmail, checkAuth }) {
@@ -197,6 +198,12 @@ Ui.prototype.setPmDone = function setPmDone (code) {
     this.pmError = code
   }
   this.pmDone = true
+}
+
+Ui.prototype.sayGoodbye = function sayGoodbye () {
+  console.log(
+    chalk.white.bold('\nThanks for supporting the Open Source community with Flossbank ♥')
+  )
 }
 
 Ui.prototype.showHelp = function showHelp () {

--- a/src/ui/summary.js
+++ b/src/ui/summary.js
@@ -31,9 +31,5 @@ module.exports = (ads) => {
     return output
   }, [chalk.white.bold('======== Flossbank Ad Summary ========\n')])
 
-  adSummary.push(
-    chalk.white.bold('\nThanks for supporting the Open Source community with Flossbank ♥')
-  )
-
   return adSummary.join('\n')
 }


### PR DESCRIPTION
**Before this PR**: If the API returns an empty list of ads, the CLI "fires and forgets" the package manager.

**After this PR**: If the API returns an empty list of ads, the CLI runs the package manager visibly and then completes the session with an empty `seen` ads list. Passthrough mode ("fire and forget") is only used if the API call results in an error.

**Demo (using local API that returns no ads)**:
![no-ads](https://user-images.githubusercontent.com/2707340/77236474-25a66500-6b7c-11ea-9228-65f463bdc38a.gif)
