### PR TITLE
Windows install script

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -92,12 +92,7 @@ if ($LASTEXITCODE -ne 0) {
   & $FlossbankExe 'auth'
 }
 
-$User = [EnvironmentVariableTarget]::User
-$Path = [Environment]::GetEnvironmentVariable('Path', $User)
-if (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
-  [Environment]::SetEnvironmentVariable('Path', "$Path;$BinDir", $User)
-  $Env:Path += ";$BinDir"
-}
+. "$FlossbankInstall\env.ps1"
 
 Write-Output ""
 Write-Output "Flossbank ($FlossbankVersion) is now installed and registered. Great!"

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -4,7 +4,7 @@
 # Thanks deno.land for inspiration <3
 $ErrorActionPreference = 'Stop'
 
-$Target = 'windows-x86_64'
+$Target = 'win-x86_64'
 
 $FlossbankInstall = $env:FLOSSBANK_INSTALL
 $BinDir = if ($FlossbankInstall) {
@@ -78,14 +78,18 @@ Expand-Archive $FlossbankZip -Destination $BinDir -Force
 Remove-Item $FlossbankZip
 
 Write-Output ""
-$FlossbankExe install "$FlossbankInstall"
-$FlossbankExe wrap all
+$InstallArgs = "install", "$FlossbankInstall"
+$WrapArgs = "wrap", "all"
+
+& $FlossbankExe $InstallArgs
+& $FlossbankExe $WrapArgs
 Write-Output ""
 
-if (!($FlossbankExe check)) {
+& $FlossbankExe 'check'
+if ($LASTEXITCODE -ne 0) {
   Write-Output "The next step is to verify your email address."
   Write-Output ""
-  $FlossbankExe auth
+  & $FlossbankExe 'auth'
 }
 
 $User = [EnvironmentVariableTarget]::User

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -1,0 +1,100 @@
+#!/usr/bin/env pwsh
+# Copyright 2020 the Flossbank authors. All rights reserved. MIT license.
+# TODO(everyone): Keep this script simple and easily auditable.
+# Thanks deno.land for inspiration <3
+$ErrorActionPreference = 'Stop'
+
+$Target = 'windows-x86_64'
+
+$FlossbankInstall = $env:FLOSSBANK_INSTALL
+$BinDir = if ($FlossbankInstall) {
+  "$FlossbankInstall\bin"
+} else {
+  "$Home\.flossbank\bin"
+}
+
+if (!(Test-Path $BinDir)) {
+  New-Item $BinDir -ItemType Directory | Out-Null
+}
+
+Write-Output ""
+Write-Output "Welcome to Flossbank!"
+Write-Output ""
+Write-Output "This script will download and install the latest version of Flossbank,"
+Write-Output "a package manager wrapper that helps compensate open source maintainers."
+Write-Output ""
+Write-Output "It will add the 'flossbank' command to Flossbank's bin directory, located at:"
+Write-Output ""
+Write-Output "$BinDir"
+Write-Output ""
+Write-Output "This path will then be added to your PATH environment variable by"
+Write-Output "modifying your shell profile/s."
+Write-Output ""
+Write-Output "You can uninstall at any time by executing 'flossbank --uninstall'"
+Write-Output "and these changes will be reverted."
+Write-Output ""
+
+# GitHub requires TLS 1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$Response = Invoke-WebRequest 'https://github.com/flossbank/cli/releases/latest' -UseBasicParsing
+$FlossbankUri = {
+  $Response = Invoke-WebRequest 'https://github.com/flossbank/cli/releases/latest' -UseBasicParsing
+  if ($PSVersionTable.PSEdition -eq 'Core') {
+    $Response.Links |
+      Where-Object { $_.href -like "/flossbank/cli/releases/download/*/flossbank-${Target}.zip" } |
+      ForEach-Object { 'https://github.com' + $_.href } |
+      Select-Object -First 1
+  } else {
+    $HTMLFile = New-Object -Com HTMLFile
+    if ($HTMLFile.IHTMLDocument2_write) {
+      $HTMLFile.IHTMLDocument2_write($Response.Content)
+    } else {
+      $ResponseBytes = [Text.Encoding]::Unicode.GetBytes($Response.Content)
+      $HTMLFile.write($ResponseBytes)
+    }
+    $HTMLFile.getElementsByTagName('a') |
+      Where-Object { $_.href -like "about:/flossbank/cli/releases/download/*/flossbank-${Target}.zip" } |
+      ForEach-Object { $_.href -replace 'about:', 'https://github.com' } |
+      Select-Object -First 1
+  }
+}
+
+if (!$FlossbankUri) {
+  Write-Output ""
+  Write-Output "Error: unable to locate latest release on GitHub. Please try again or email support@flossbank.com for help!"
+  exit 1
+}
+$FlossbankVersion = $FlossbankUri.Split("/")[7]
+$FlossbankFileName = $FlossbankUri.Split("/")[8]
+
+$FlossbankZip = "$BinDir\flossbank.zip"
+$FlossbankExe = "$BinDir\flossbank.exe"
+
+Write-Output "Installing version: $FlossbankVersion"
+Write-Output "  - Downloading $FlossbankFileName..."
+
+Invoke-WebRequest $FlossbankUri -OutFile $FlossbankZip -UseBasicParsing
+Expand-Archive $FlossbankZip -Destination $BinDir -Force
+Remove-Item $FlossbankZip
+
+Write-Output ""
+$FlossbankExe install "$FlossbankInstall"
+$FlossbankExe wrap all
+Write-Output ""
+
+if (!($FlossbankExe check)) {
+  Write-Output "The next step is to verify your email address."
+  Write-Output ""
+  $FlossbankExe auth
+}
+
+$User = [EnvironmentVariableTarget]::User
+$Path = [Environment]::GetEnvironmentVariable('Path', $User)
+if (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
+  [Environment]::SetEnvironmentVariable('Path', "$Path;$BinDir", $User)
+  $Env:Path += ";$BinDir"
+}
+
+Write-Output ""
+Write-Output "Flossbank ($FlossbankVersion) is now installed and registered. Great!"
+Write-Output ""

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Copyright 2020 Flossbank. All rights reserved. MIT license.
 # TODO(everyone): Keep this script simple and easily auditable.
+# Thanks deno.land for inspiration <3
 set -e
 
 case $(uname -s) in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flossbank/cli",
-	"version": "0.0.25",
+	"version": "0.0.26",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flossbank/cli",
-	"version": "0.0.25",
+	"version": "0.0.26",
 	"license": "MIT",
 	"bin": {
 		"flossbank": "src/index.js"


### PR DESCRIPTION
Implemented PowerShell install script. Most of the "flossbank" parts are tested; the GitHub download section was adapted from Deno's installer and hasn't been tested yet. 

This installer is very Windows-specific; we will direct all non-Windows users (and WSL users) to use the `install.sh` script (even if they have PowerShell installed). 

One happy coincidence is we can actually modify the current session's environment, so at the end of the installer we directly source the env file: `. "$FlossbankInstall\env.ps1"`. This brings `flossbank` into `$PATH` as well as the wrapped package managers. So Windows users don't need to close/reopen to get the Flossbank experience.