### PR TITLE
Update install.ps1

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -68,7 +68,7 @@ echo
 echo "This path will then be added to your PATH environment variable by"
 echo "modifying your shell profile/s."
 echo
-echo "You can uninstall at any time by executing 'flossbank --uninstall'"
+echo "You can uninstall at any time by executing 'flossbank uninstall'"
 echo "and these changes will be reverted."
 echo
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,7 +28,5 @@ module.exports = {
       $ flossbank npm install
     To run \`yarn add meow\` through Flossbank:
       $ flossbank yarn add meow
-    To authenticate (or re-authenticate) with the Flossbank API:
-      $ flossbank --auth
 `
 }

--- a/src/env/index.js
+++ b/src/env/index.js
@@ -2,6 +2,7 @@ const { promises: { writeFile } } = require('fs')
 const path = require('path')
 const makeDir = require('make-dir')
 const del = require('del')
+const os = require('os')
 
 /**
  * Env is responsible for writing the $FLOSSBANK_DIR/env and env.ps1 files
@@ -63,7 +64,8 @@ class Env {
   _getPowerPathModifier () {
     const installDir = this.config.getInstallDir()
     const binDir = path.join(installDir, 'bin')
-    return `$ENV:PATH="$ENV:PATH;${binDir}"`
+    const separator = os.platform() === 'win32' ? ';' : ':'
+    return `$ENV:PATH="$ENV:PATH${separator}${binDir}"`
   }
 }
 


### PR DESCRIPTION
Tested on Windows PowerShell and PowerShell Core (on Windows). Same experience in both cases. 

~~If I have enough spoons, I might try to make this `install.ps1` script work on Mac and Linux too (since `pwsh` is cross-platform). But for now it should be fine for them to use the `install.sh` script.~~

The `install.ps1` script now supports Mac and Linux too (tested on Mac); so if a curious (non-Windows) PowerShell user wants to, they can use the PowerShell install option no problem.