### PR TITLE
Conf update

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -71,7 +71,10 @@ module.exports = async ({ runlog, client, pm, ui, args }) => {
     runlog.error('failed to get session data: %O', e)
   }
 
-  if (initialAdBatchSize < 1 || pm.isQuietMode()) {
+  // if not in a TTY, we won't display ads (unless we're debugging, which is what runlog.enabled means)
+  const inATerminalOrDebugging = process.stdout.isTTY || runlog.enabled
+
+  if (initialAdBatchSize < 1 || pm.isQuietMode() || !inATerminalOrDebugging) {
     // we will not start the UI, but we will "complete" this is no-ads session
     runlog.record(runlog.keys.SILENT_MODE, true)
     return pm.passthrough(async (err, code) => {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -9,7 +9,10 @@ const {
 
 class Config {
   constructor () {
-    this.conf = new Conf({ projectName: PROJECT_NAME })
+    this.conf = new Conf({
+      projectName: PROJECT_NAME,
+      projectSuffix: ''
+    })
   }
 
   getInstallHost () {


### PR DESCRIPTION
1. Config is now always in a `flossbank` folder, not `flossbank-nodejs`
2. If `process.stdout` is not a terminal, don't show ads

In re (2), here I am piping output of `npm install` to a log file and then printing the log file:
![image](https://user-images.githubusercontent.com/2707340/84086686-4b821f80-a99d-11ea-96d7-0e3e7be4b466.png)
You can see that an ad was "shown", but of course nobody saw it. After this PR is merged:
![image](https://user-images.githubusercontent.com/2707340/84086946-e5e26300-a99d-11ea-81ac-f44814e1a73a.png)
No ads were shown. The reason there are npm WARN statements in the above piped output is because npm logs to `stderr` by default; in "ads mode" we collect all of npm's  output (`stdout` and `stderr`) and print it on `stdout`. So this latest snapshot demonstrates that, when piping, we are running in silent/passthrough mode properly (stderr wasn't piped with `2>&1` in the example).
